### PR TITLE
Fixed broken print statement in python script

### DIFF
--- a/PythonScript/fantemp.py
+++ b/PythonScript/fantemp.py
@@ -28,7 +28,7 @@ try:
     opts, args = getopt.getopt(sys.argv[1:],
         "p:t:v", ["pin=", "temp=", "verbose"])
 except getopt.GetoptError:
-    print "Usage: fantemp.py [-t <temperature] [-p <GPIO pin #>]"
+    print("Usage: fantemp.py [-t <temperature] [-p <GPIO pin #>]")
     sys.exit(2)
 
 for opt, arg in opts:


### PR DESCRIPTION
Print statement in the first try block on line 31 was formatted for python2 only. I've updated it to work with python2 or python3. 
